### PR TITLE
Create startxfce4_termux(old-android).sh

### DIFF
--- a/scripts/termux_native/startxfce4_termux(old-android).sh
+++ b/scripts/termux_native/startxfce4_termux(old-android).sh
@@ -1,0 +1,26 @@
+#!/data/data/com.termux/files/usr/bin/bash
+
+# Kill open X11 processes
+kill -9 $(pgrep -f "termux.x11") 2>/dev/null
+
+# Enable PulseAudio over Network
+pulseaudio --start --load="module-native-protocol-tcp auth-ip-acl=127.0.0.1 auth-anonymous=1" --exit-idle-time=-1
+
+# Prepare termux-x11 session
+export XDG_RUNTIME_DIR=${TMPDIR}
+termux-x11 :0 -legacy-drawing >/dev/null &
+
+# Wait a bit until termux-x11 gets started.
+sleep 3
+
+# Launch Termux X11 main activity
+am start --user 0 -n com.termux.x11/com.termux.x11.MainActivity > /dev/null 2>&1
+sleep 1
+
+# Set audio server
+export PULSE_SERVER=127.0.0.1
+
+# Run XFCE4 Desktop
+env DISPLAY=:0 dbus-launch --exit-with-session xfce4-session & > /dev/null 2>&1
+
+exit 0


### PR DESCRIPTION
For older android versions created the startxfce4_terminal(old-android).sh 
with -legacy-drawing to fix the blackscreen on Android lower than 9. Just add the link to the termux native README section.