### PR TITLE
Fix sudoers permission issue

### DIFF
--- a/Documentation/chroot/arch_chroot.md
+++ b/Documentation/chroot/arch_chroot.md
@@ -159,7 +159,7 @@ passwd droidmaster
 
 - Add the user to `sudoers` file so you can execute `sudo` commands
 ```
-nano /etc/sudoers
+sudo visudo
 ```
 ```
 # Paste this 

--- a/Documentation/chroot/arch_chroot.md
+++ b/Documentation/chroot/arch_chroot.md
@@ -159,7 +159,7 @@ passwd droidmaster
 
 - Add the user to `sudoers` file so you can execute `sudo` commands
 ```
-sudo visudo
+visudo
 ```
 ```
 # Paste this 

--- a/Documentation/chroot/debian_chroot.md
+++ b/Documentation/chroot/debian_chroot.md
@@ -192,7 +192,7 @@ passwd droidmaster
 
 9. Add the created user to sudoers file to have superuser privileges: 
 ```
-sudo visudo
+visudo
 ```
 Add this line: 
 ```

--- a/Documentation/chroot/debian_chroot.md
+++ b/Documentation/chroot/debian_chroot.md
@@ -192,7 +192,7 @@ passwd droidmaster
 
 9. Add the created user to sudoers file to have superuser privileges: 
 ```
-nano /etc/sudoers
+sudo visudo
 ```
 Add this line: 
 ```

--- a/Documentation/proot/alpine_proot.md
+++ b/Documentation/proot/alpine_proot.md
@@ -45,7 +45,7 @@ apk add sudo nano dbus-x11 xfce4
 * Create a new user and give it sudo privileges: 
 ```
 adduser droidmaster
-nano /etc/sudoers
+sudo visudo
 
 # Add the following line to the sudoers file
 droidmaster All=(ALL:ALL) ALL

--- a/Documentation/proot/alpine_proot.md
+++ b/Documentation/proot/alpine_proot.md
@@ -45,7 +45,7 @@ apk add sudo nano dbus-x11 xfce4
 * Create a new user and give it sudo privileges: 
 ```
 adduser droidmaster
-sudo visudo
+visudo
 
 # Add the following line to the sudoers file
 droidmaster All=(ALL:ALL) ALL

--- a/Documentation/proot/arch_proot.md
+++ b/Documentation/proot/arch_proot.md
@@ -67,7 +67,7 @@ passwd droidmaster
 ```
 * Give sudo permissions to the user
 ```
-nano /etc/sudoers
+sudo visudo
 ```
 ```
 # Paste the following line
@@ -107,7 +107,7 @@ passwd droidmaster
 ```
 * Give sudo permissions to the user
 ```
-nano /etc/sudoers
+sudo visudo
 ```
 ```
 # Paste the following line

--- a/Documentation/proot/arch_proot.md
+++ b/Documentation/proot/arch_proot.md
@@ -67,7 +67,7 @@ passwd droidmaster
 ```
 * Give sudo permissions to the user
 ```
-sudo visudo
+visudo
 ```
 ```
 # Paste the following line
@@ -107,7 +107,7 @@ passwd droidmaster
 ```
 * Give sudo permissions to the user
 ```
-sudo visudo
+visudo
 ```
 ```
 # Paste the following line

--- a/Documentation/proot/debian_proot.md
+++ b/Documentation/proot/debian_proot.md
@@ -60,7 +60,7 @@ adduser droidmaster
 ```
 3. Give the user sudo privileges
 ```
-nano /etc/sudoers
+sudo visudo
 
 # Add the following line to the file
 droidmaster ALL=(ALL:ALL) ALL

--- a/Documentation/proot/debian_proot.md
+++ b/Documentation/proot/debian_proot.md
@@ -60,7 +60,7 @@ adduser droidmaster
 ```
 3. Give the user sudo privileges
 ```
-sudo visudo
+visudo
 
 # Add the following line to the file
 droidmaster ALL=(ALL:ALL) ALL

--- a/Documentation/proot/voidlinux.md
+++ b/Documentation/proot/voidlinux.md
@@ -52,7 +52,7 @@ xbps-install lxde xfce4 xfce4-terminal
 useradd droidmaster
 passwd droidmaster
 
-sudo visudo
+visudo
 
 # Add the following line to the sudoers file
 droidmaster All=(ALL:ALL) ALL

--- a/Documentation/proot/voidlinux.md
+++ b/Documentation/proot/voidlinux.md
@@ -52,7 +52,7 @@ xbps-install lxde xfce4 xfce4-terminal
 useradd droidmaster
 passwd droidmaster
 
-nano /etc/sudoers
+sudo visudo
 
 # Add the following line to the sudoers file
 droidmaster All=(ALL:ALL) ALL

--- a/README_old.md
+++ b/README_old.md
@@ -98,7 +98,7 @@ adduser droidmaster
 ```
 3. Give the user sudo privileges
 ```
-sudo visudo
+visudo
 
 # Add the following line to the file
 droidmaster ALL=(ALL:ALL) ALL
@@ -686,7 +686,7 @@ passwd droidmaster
 
 10. Add the created user to sudoers file to have superuser privileges: 
 ```
-sudo visudo
+visudo
 ```
 Add this line: 
 ```

--- a/README_old.md
+++ b/README_old.md
@@ -98,7 +98,7 @@ adduser droidmaster
 ```
 3. Give the user sudo privileges
 ```
-nano /etc/sudoers
+sudo visudo
 
 # Add the following line to the file
 droidmaster ALL=(ALL:ALL) ALL
@@ -686,7 +686,7 @@ passwd droidmaster
 
 10. Add the created user to sudoers file to have superuser privileges: 
 ```
-nano /etc/sudoers
+sudo visudo
 ```
 Add this line: 
 ```


### PR DESCRIPTION
The `/etc/sudoers` file is read-only(permission `0440`) even for the root user to prevent accidental modifications.

`visudo` is used to securely edit the sudoers file.